### PR TITLE
Fix profile link path

### DIFF
--- a/src/Pages/Profile/Profile.jsx
+++ b/src/Pages/Profile/Profile.jsx
@@ -149,9 +149,7 @@ function Profile() {
             </span>
           </div>
           <h2 className="profile-name">{userData.nama}</h2>
-          <a href="http://localhost:3000/Healthy-Life-Kelompok-2/GetStarted">
-            Isi Biodata Kembali?
-          </a>
+          <a href="/getstarted">Isi Biodata Kembali?</a>
         </div>
 
         <div className="profile-stats">


### PR DESCRIPTION
## Summary
- fix link to getstarted page in Profile

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684041a93a0c83318d4386253771b1e5