### PR TITLE
Fix delete profile ID

### DIFF
--- a/src/Pages/Profile/Profile.jsx
+++ b/src/Pages/Profile/Profile.jsx
@@ -55,7 +55,7 @@ function Profile() {
       try {
         const response = await axios.delete(
           `http://localhost/healty_life/backend/profile.php`,
-          { data: { id: userData.id } }
+          { data: { id: userData.id_pengguna || formData.id } }
         );
 
         if (response.data.success) {


### PR DESCRIPTION
## Summary
- use `id_pengguna` or form data when deleting a profile

## Testing
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68404d264d5483319e7358da93d3a732