### PR TITLE
Add navbar test with React Testing Library

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "build": "react-scripts build",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --watchAll=false",
     "eject": "react-scripts eject"
   },
   "browserslist": {

--- a/src/__tests__/Navbar.test.jsx
+++ b/src/__tests__/Navbar.test.jsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Navbar from '../components/Navbar/Navbar';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('Navbar', () => {
+  test('renders login and sign-up links when not logged in', () => {
+    render(
+      <MemoryRouter>
+        <Navbar />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('link', { name: /sign up/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /^log in$/i })).toBeInTheDocument();
+  });
+});

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- add Jest setup file
- add Navbar.test.jsx to verify login and sign-up link rendering
- run tests in non-watch mode

## Testing
- `npm test --silent --color=false`

------
https://chatgpt.com/codex/tasks/task_e_684054f48ed48331b965ae5ec27fe898